### PR TITLE
Add configurable XRayGenericTestsCreatingConsumer failure processing

### DIFF
--- a/core/src/main/java/com/devexperts/switchboard/entities/valuesupplier/BlockFormattingValuesExtractor.java
+++ b/core/src/main/java/com/devexperts/switchboard/entities/valuesupplier/BlockFormattingValuesExtractor.java
@@ -37,8 +37,7 @@ public class BlockFormattingValuesExtractor implements TestRunValuesExtractor, T
     @JsonProperty(defaultValue = "false")
     private boolean showEmptyBlocks = false;
 
-    private BlockFormattingValuesExtractor() {
-    }
+    private BlockFormattingValuesExtractor() {}
 
     public BlockFormattingValuesExtractor(List<Pair<String, ValuesExtractor>> blockExtractors,
                                           String headerSeparator,

--- a/core/src/main/java/com/devexperts/switchboard/impl/extractors/FileTestExtractor.java
+++ b/core/src/main/java/com/devexperts/switchboard/impl/extractors/FileTestExtractor.java
@@ -83,7 +83,9 @@ public abstract class FileTestExtractor<F extends IntegrationFeatures> implement
                 .flatMap(Collection::stream)
                 .collect(Collectors.toList());
         log.info("Extracted {} tests from {} files in {} millis", tests.size(), paths.size(), System.currentTimeMillis() - start);
-        log.trace("Extracted tests: {}\n\t", tests.stream().map(Test::getIdentifier).collect(Collectors.joining("\n\t")));
+        if (log.isTraceEnabled()) {
+            log.trace("Extracted tests: {}\n\t", tests.stream().map(Test::getIdentifier).collect(Collectors.joining("\n\t")));
+        }
         return tests;
     }
 }

--- a/integrations/jira/src/main/java/com/devexperts/switchboard/integrations/jira/JiraIntegrationFeatures.java
+++ b/integrations/jira/src/main/java/com/devexperts/switchboard/integrations/jira/JiraIntegrationFeatures.java
@@ -72,8 +72,7 @@ public class JiraIntegrationFeatures implements IntegrationFeatures {
     private final DisposableHttpClient httpClient;
 
     JiraIntegrationFeatures(URI serverUri, String username, String password, int socketTimeoutSeconds, int searchQueryBatch,
-                            int requestsLimitCount, int requestsLimitPeriodSeconds)
-    {
+                            int requestsLimitCount, int requestsLimitPeriodSeconds) {
         this.serverUri = serverUri;
         this.socketTimeoutSeconds = socketTimeoutSeconds;
         this.searchQueryBatch = searchQueryBatch;

--- a/integrations/jira/src/test/groovy/com/devexperts/switchboard/integrations/jira/JiraIntegrationTest.groovy
+++ b/integrations/jira/src/test/groovy/com/devexperts/switchboard/integrations/jira/JiraIntegrationTest.groovy
@@ -100,7 +100,7 @@ class JiraIntegrationTest {
                 "Severity"    : new ConstantValuesExtractor("Functional"),
                 "Description" : new ConstantValuesExtractor(lorem),
                 "Test Type"   : new ConstantValuesExtractor("Automated")
-        ] as Map, false, null)
+        ] as Map, null, false, true)
         consumer.init(getMockIntegrationFeatures())
 
         ObjectMapper mapper = JacksonUtils.getMapper()

--- a/sandbox/src/main/java/com/devexperts/switchboard/sandbox/examples/jira/TestCreatingConsumerExample.java
+++ b/sandbox/src/main/java/com/devexperts/switchboard/sandbox/examples/jira/TestCreatingConsumerExample.java
@@ -157,15 +157,17 @@ public final class TestCreatingConsumerExample {
         Pair<String, TestValuesExtractor> xrayFieldLinkToTestAttribute =
             Pair.of("Unique ID", new AttributeValuesExtractor(TEST_DETAILS, "uniqueID", ","));
 
-        return new XRayGenericTestsCreatingConsumer(
-                "Jira-Test-Creator",          // identifier
-                "QWERTY",                     // Jira project id
-                "Test",                       // Jira issue type for Test Case
-                summaryExtractor,             // A complex extractor to construct summary
-                fieldValuesExtractors,        // Field values extractors
-                defaultFieldValues,           // Default field values if not found in tests
-                true,                         // update existing XRay tests content or ignore changes
-                xrayFieldLinkToTestAttribute
+        XRayGenericTestsCreatingConsumer consumer = new XRayGenericTestsCreatingConsumer(
+            "Jira-Test-Creator",            // identifier
+            "QWERTY",                        // Jira project id
+            "Test",                         // Jira issue type for Test Case
+            summaryExtractor,               // A complex extractor to construct summary
+            fieldValuesExtractors,          // Field values extractors
+            defaultFieldValues,             // Default field values if not found in tests
+            xrayFieldLinkToTestAttribute,   // mapping between autotests and XRay tests
+            true,                           // update existing XRay tests content or ignore changes
+            true                            // use failSafeStrategy strategy
         );
+        return consumer;
     }
 }


### PR DESCRIPTION
We had fail-fast Jira integration XRayGenericTestsCreatingConsumer execution strategy. Added optional fail-safe approach to be able to collect all failures